### PR TITLE
refactor: remove need for parent pom.  use simply for managing modules

### DIFF
--- a/dgs-extended-formatters/pom.xml
+++ b/dgs-extended-formatters/pom.xml
@@ -3,12 +3,6 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>io.github.setchy</groupId>
-        <artifactId>dgs-extended-formatters-parent</artifactId>
-        <version>0.0.4-SNAPSHOT</version>
-    </parent>
-
     <groupId>io.github.setchy</groupId>
     <artifactId>dgs-extended-formatters</artifactId>
     <version>0.0.4-SNAPSHOT</version>
@@ -33,6 +27,13 @@
     </scm>
 
     <properties>
+        <!-- Java version target -->
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+
+        <!-- Dependencies -->
+        <dgs-platform-dependencies.version>5.2.1</dgs-platform-dependencies.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-text.version>1.9</commons-text.version>
 
@@ -42,12 +43,29 @@
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
 
+        <!-- Sonarcloud details -->
+        <sonar.organization>setchy</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+
         <!-- Release plugins -->
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.netflix.graphql.dgs</groupId>
+                <artifactId>graphql-dgs-platform-dependencies</artifactId>
+                <!-- The DGS BOM/platform dependency. This is the only place you set version of DGS -->
+                <version>${dgs-platform-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -181,4 +199,15 @@
             </build>
         </profile>
     </profiles>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/dgs-extended-formatters/pom.xml
+++ b/dgs-extended-formatters/pom.xml
@@ -43,10 +43,6 @@
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
 
-        <!-- Sonarcloud details -->
-        <sonar.organization>setchy</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-
         <!-- Release plugins -->
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,4 +12,11 @@
         <module>dgs-extended-formatters</module>
         <module>samples</module>
     </modules>
+
+    <properties>
+        <!-- Sonarcloud details -->
+        <sonar.organization>setchy</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    </properties>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,68 +5,11 @@
 
     <groupId>io.github.setchy</groupId>
     <artifactId>dgs-extended-formatters-parent</artifactId>
-    <packaging>pom</packaging>
     <version>0.0.4-SNAPSHOT</version>
-
-    <name>${project.artifactId}</name>
-    <description>A set of DGS Directives for common formatting use-cases.</description>
-    <url>https://github.com/setchy/dgs-extended-formatters</url>
+    <packaging>pom</packaging>
 
     <modules>
         <module>dgs-extended-formatters</module>
         <module>samples</module>
     </modules>
-
-    <properties>
-        <java.version>11</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
-
-        <dgs-platform-dependencies.version>5.2.2</dgs-platform-dependencies.version>
-
-        <!-- Sonarcloud details -->
-        <sonar.organization>setchy</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.netflix.graphql.dgs</groupId>
-                <artifactId>graphql-dgs-platform-dependencies</artifactId>
-                <!-- The DGS BOM/platform dependency. This is the only place you set version of DGS -->
-                <version>${dgs-platform-dependencies.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
-        </license>
-    </licenses>
-    <developers>
-        <developer>
-            <name>Adam Setch</name>
-            <email>adam.setch@outlook.com</email>
-        </developer>
-    </developers>
-    <scm>
-        <url>http://github.com/setchy/dgs-extended-formatters</url>
-    </scm>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
 </project>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -4,9 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.setchy</groupId>
-        <artifactId>dgs-extended-formatters-parent</artifactId>
-        <version>0.0.4-SNAPSHOT</version>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.3</version>
+        <relativePath/>
     </parent>
 
     <groupId>io.github.setchy</groupId>
@@ -17,8 +18,9 @@
     <description>A sample graphql dgs service which utilizes dgs-extended-formatters</description>
 
     <properties>
-        <spring-boot.version>2.7.3</spring-boot.version>
+        <!-- extended formatters -->
         <dgs-extended-formatters.version>0.0.4-SNAPSHOT</dgs-extended-formatters.version>
+        <dgs-platform-dependencies.version>5.2.1</dgs-platform-dependencies.version>
 
         <!-- Skip deploying this module when releasing -->
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -27,9 +29,10 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-parent</artifactId>
-                <version>${spring-boot.version}</version>
+                <groupId>com.netflix.graphql.dgs</groupId>
+                <artifactId>graphql-dgs-platform-dependencies</artifactId>
+                <!-- The DGS BOM/platform dependency. This is the only place you set version of DGS -->
+                <version>${dgs-platform-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
The parent pom was an unnecessary layer at this stage. 